### PR TITLE
[BUGFIX] Fix search updating the wrong assets

### DIFF
--- a/app/input/input.go
+++ b/app/input/input.go
@@ -65,8 +65,8 @@ Please see below for the headers of the columns not included:
 	fmt.Printf("Assets successfully updated: %d of %d\n", csvFilesToUpdate-len(notAdded), csvFilesToUpdate)
 	if len(notAdded) > 0 {
 		fmt.Println("Some assets failed to update:")
-		for origName := range notAdded {
-			fmt.Printf("Original filename: %s\n", origName)
+		for assetID := range notAdded {
+			fmt.Printf("Asset ID: %s\n", assetID)
 		}
 	}
 

--- a/internal/core/services/iconik/search/svcs.go
+++ b/internal/core/services/iconik/search/svcs.go
@@ -90,6 +90,10 @@ func (s *Svc) ValidateAndSearchAssetID(ctx context.Context, assetID, collectionI
 
 // ValidateAndSearchFilename validates an asset filename, searches for it and returns it.
 func (s *Svc) ValidateAndSearchFilename(ctx context.Context, filename, collectionID string) (search.ObjectDTO, error) {
+	if filename == "" {
+		return search.ObjectDTO{}, errors.New("filename is empty")
+	}
+
 	sch := search.Search{
 		DocTypes:      []string{"assets", "collections"},
 		Facets:        []string{"object_type", "media_type", "archive_status", "type", "format", "is_online", "approval_status"},

--- a/internal/core/services/input/svcs.go
+++ b/internal/core/services/input/svcs.go
@@ -55,7 +55,6 @@ func (svc *Svc) ProcessAssets(ctx context.Context, csvData [][]string, collectio
 
 		_, errAssetID := svc.searchSvc.ValidateAndSearchAssetID(ctx, assetID, collectionID)
 		if errAssetID != nil {
-			fmt.Println(origName)
 			result, errFilename := svc.searchSvc.ValidateAndSearchFilename(ctx, origName, collectionID)
 			if errFilename != nil {
 				log.Printf("%s & %s for %s, skipping\n", errAssetID, errFilename, title)

--- a/internal/core/services/input/svcs.go
+++ b/internal/core/services/input/svcs.go
@@ -55,10 +55,11 @@ func (svc *Svc) ProcessAssets(ctx context.Context, csvData [][]string, collectio
 
 		_, errAssetID := svc.searchSvc.ValidateAndSearchAssetID(ctx, assetID, collectionID)
 		if errAssetID != nil {
+			fmt.Println(origName)
 			result, errFilename := svc.searchSvc.ValidateAndSearchFilename(ctx, origName, collectionID)
 			if errFilename != nil {
 				log.Printf("%s & %s for %s, skipping\n", errAssetID, errFilename, title)
-				notAdded[origName] = true
+				notAdded[assetID] = true
 				continue
 			}
 			assetID = result.ID


### PR DESCRIPTION
Fixing a bug where:

If an asset in the input csv isn't in the collection id provided, it moves onto searching iconik with the original_filename provided. However, if that is blank, it will search using a wildcard, and so find the first asset it comes to and updates that instead.

Have added a simple check for a blank original_filename.